### PR TITLE
Prevent exec from closing the process

### DIFF
--- a/.scripts/test.js
+++ b/.scripts/test.js
@@ -59,10 +59,11 @@ function runEndToEndTests(callback) {
 }
 
 function startProcess(opts, callback) {
+  var options = extend({ maxBuffer: Number.MAX_SAFE_INTEGER }, opts.options);
 
   var proc = exec(
      opts.command,
-     opts.options
+     options
   );
   proc.stdout.pipe(process.stdout);
   proc.stderr.pipe(process.stderr);


### PR DESCRIPTION
Added maxBuffer to prevent exec from closing the process. It automatically closes the process if the stdout buffer is filled (large projects with 2000+ steps). See https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback